### PR TITLE
FIX libsnark test failure.

### DIFF
--- a/src/snark/src/algebra/fields/bigint.tcc
+++ b/src/snark/src/algebra/fields/bigint.tcc
@@ -201,7 +201,7 @@ inline bigint<m> bigint<n>::shorten(const bigint<m>& q, const char *msg) const
         }
     }
     bigint<m> res;
-    mpn_copyi(res.data, data, n);
+    mpn_copyi(res.data, data, m);
     res.limit(q, msg);
     return res;
 }


### PR DESCRIPTION
https://github.com/zcash/zcash/commit/4a617475ecc5d5a5821920de4f49871bd9ba99d4
この一箇所を直すと、macで発生していた同期が119ブロック目で止まる問題がFixします