### PR TITLE
Fix libsnark test failure.

### DIFF
--- a/src/snark/src/algebra/fields/bigint.tcc
+++ b/src/snark/src/algebra/fields/bigint.tcc
@@ -201,7 +201,7 @@ inline bigint<m> bigint<n>::shorten(const bigint<m>& q, const char *msg) const
         }
     }
     bigint<m> res;
-    mpn_copyi(res.data, data, n);
+    mpn_copyi(res.data, data, m);
     res.limit(q, msg);
     return res;
 }


### PR DESCRIPTION
zcash/zcash@4a61747
この一箇所を直すと、macで発生していた同期が119ブロック目で止まる問題がFixします。
先程一度間違えて自分でマージしてしまったので、もう一度同じ内容ですがプルリクエストします。
申し訳ありません。