### PR TITLE
fixed build error when PATH includes white spaces

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -129,9 +129,9 @@ $(1)_config_env+=$($(1)_config_env_$(host_arch)_$(host_os)) $($(1)_config_env_$(
 
 $(1)_config_env+=PKG_CONFIG_LIBDIR=$($($(1)_type)_prefix)/lib/pkgconfig
 $(1)_config_env+=PKG_CONFIG_PATH=$($($(1)_type)_prefix)/share/pkgconfig
-$(1)_config_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_build_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_stage_env+=PATH=$(build_prefix)/bin:$(PATH)
+$(1)_config_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_build_env+=PATH="$(build_prefix)/bin:$(PATH)"
+$(1)_stage_env+=PATH="$(build_prefix)/bin:$(PATH)"
 $(1)_autoconf=./configure --host=$($($(1)_type)_host) --disable-dependency-tracking --prefix=$($($(1)_type)_prefix) $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
 
 ifneq ($($(1)_nm),)


### PR DESCRIPTION
Windows Linux Subsystem (Ubuntu)で、パスに "Program FIles (x86)" みたいなものが含まれているとビルド時に `./zcutil/build.sh --disable-rust` のところでエラーが出るため修正しました。

ちなみに、ZCashではこちらのCommitで対応されています。
https://github.com/zcash/zcash/commit/35e12d992acf15123dcfa16f2e5fba39bb87e4ce#diff-4305953da1e12ddb11cd242d42ad00f7